### PR TITLE
Add CI, tasty tests + autodiscover, add Aeson constraint

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,7 +20,7 @@ jobs:
           - "8.8.4"
           - "8.10.7"
     env:
-      CONFIG: "--enable-tests --enable-benchmarks"
+      CONFIG: "--enable-tests" # --enable-benchmarks
 
     steps:
       - uses: actions/checkout@v2
@@ -41,6 +41,6 @@ jobs:
       - run: cabal install tasty-discover
       - run: cabal build $CONFIG
       - run: cabal test $CONFIG --test-show-details=always
-      - run: cabal bench $CONFIG
+#     - run: cabal bench $CONFIG
       - run: cabal haddock $CONFIG
       - run: cabal sdist

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,46 @@
+name: Haskell CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cabal:
+          - "3.6"
+        ghc:
+          - "8.6.5"
+          - "8.8.4"
+          - "8.10.7"
+    env:
+      CONFIG: "--enable-tests --enable-benchmarks"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-haskell@v1.1.4
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+      - run: cabal update
+      - run: cabal freeze $CONFIG
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-
+      - run: cabal install tasty-discover
+      - run: cabal build $CONFIG
+      - run: cabal test $CONFIG --test-show-details=always
+      - run: cabal bench $CONFIG
+      - run: cabal haddock $CONFIG
+      - run: cabal sdist

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # anki-tools
 
+[![Haskell CI Status](https://github.com/zohl/anki-tools/workflows/Haskell%20CI/badge.svg)](https://github.com/zohl/anki-tools/actions/workflows/haskell.yml)
+
 ## Description
 Tools for interacting with Anki database
 

--- a/anki-tools.cabal
+++ b/anki-tools.cabal
@@ -54,15 +54,22 @@ library
   else
     ghc-options:      -Wall -Werror -O2
 
-
-executable anki-tools-test
-  hs-source-dirs:     test
-  main-is:            Main.hs
-  build-depends: base >= 4.7 && < 5.0
-               , anki-tools
-               , data-default
-
-  default-language:    Haskell2010
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: test.hs
+  other-modules:
+      MainTest
+  hs-source-dirs:
+      test
+  build-depends:
+      base >=4.8 && <5
+    , anki-tools
+    , data-default
+    , hspec
+    , tasty
+    , tasty-discover
+    , tasty-hspec
+  default-language: Haskell2010
 
   if flag(dev)
     ghc-options:      -Wall -Werror

--- a/anki-tools.cabal
+++ b/anki-tools.cabal
@@ -33,7 +33,7 @@ library
     Anki.UserProfile
 
   build-depends: base >=4.8 && < 5.0
-               , aeson
+               , aeson <2
                , bytestring
                , data-default
                , directory

--- a/anki-tools.cabal
+++ b/anki-tools.cabal
@@ -52,7 +52,7 @@ library
   if flag(dev)
     ghc-options:      -Wall -Werror
   else
-    ghc-options:      -O2 -Wall
+    ghc-options:      -Wall -Werror -O2
 
 
 executable anki-tools-test
@@ -67,4 +67,4 @@ executable anki-tools-test
   if flag(dev)
     ghc-options:      -Wall -Werror
   else
-    ghc-options:      -O2 -Wall
+    ghc-options:      -Wall -Werror -O2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-18.13

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,8 +4,8 @@ import Data.Default (def)
 import System.Environment (getArgs)
 import Anki.Tools
 import Anki.Collection
-import Anki.Note
-import Anki.Card
+-- import Anki.Note
+-- import Anki.Card
 import Anki.UserProfile
 
 
@@ -28,15 +28,8 @@ main = do
   args <- splitArgs <$> getArgs
 
   userProfile <- getUserProfile $ lookup "--user-profile" args
-  -- let output = show userProfile
-
-  -- collection <- getCollection userProfile $ read <$> (lookup "--collection" args)
-  -- let output = show collection
-
-  -- notes <- getNotes def userProfile
-  -- let output = show notes
-
+  _collection <- getCollection userProfile $ read <$> (lookup "--collection" args)
+  _notes <- getNotes def userProfile
   cards <- getCards def userProfile
-  let output = show cards
 
-  putStrLn output
+  putStrLn (show cards)

--- a/test/MainTest.hs
+++ b/test/MainTest.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 
+module MainTest where
+
 import Data.Default (def)
 import System.Environment (getArgs)
 import Anki.Tools
@@ -8,6 +10,14 @@ import Anki.Collection
 -- import Anki.Card
 import Anki.UserProfile
 
+import Test.Hspec
+
+spec_getUserProfile :: Spec
+spec_getUserProfile =
+  describe "getUserProfile" $
+    it "somehow handles Nothing" $ do
+      userProfile <- getUserProfile Nothing
+      userProfile `shouldBe` UserProfile "default"
 
 splitArgs :: [String] -> [(String, String)]
 splitArgs []       = []

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover #-}


### PR DESCRIPTION
- Add CI, always enable -Werror, add stack.yaml, fix warnings

  When pushing to 'master' or when submitting a PR, run tests in CI.

  Add a stack.yaml for those who like 'stack ...' instead of 'cabal ...'

- Add CI badge to README.md

- Add tasty, hspec, hspec-disover, and add one test that fails

  This test should probably fail when it throws because of a missing Anki
  database. This test can be fixed by replacing the default with something
  that ships with the test suite. The Default instance should probably be
  moved to the test suite, since a library cannot easily assume where on a
  system something is installed.

  ```
  test/test.hs
    getUserProfile
      getUserProfile
        somehow handles Nothing: FAIL
          uncaught exception: SQLError
          SQLite3 returned ErrorCan'tOpen while attempting to perform open
            "/home/simon/Documents/Anki/prefs.db": unable to open database file
  ```

- Constrain Aeson to <2

  The better solution is to use Aeson 2's KeyMap:

  https://frasertweedale.github.io/blog-fp/posts/2021-10-12-aeson-hash-flooding-protection.html

  but using a version <2 is the least involved solution.